### PR TITLE
AtomとRDF両方のフィードに対応する

### DIFF
--- a/lib/fragile/plugin/rss_input.rb
+++ b/lib/fragile/plugin/rss_input.rb
@@ -4,6 +4,20 @@ require "rss"
 module Fragile
   module Plugin
     class RssInput
+      module FeedItemNormalizer
+        def title
+          super.content
+        rescue
+          super
+        end
+
+        def link 
+          super.href
+        rescue
+          super
+        end
+      end
+
       def initialize(config)
         @url = config[:url]
       end
@@ -11,6 +25,7 @@ module Fragile
       def call(data=[])
         rss = RSS::Parser.parse(@url)
         urls = rss.items.map do |item|
+          item.extend FeedItemNormalizer
           { :title => item.title, :link => item.link }
         end
         data + urls


### PR DESCRIPTION
RSS::Parserはフィードの種類が異なった場合，返すオブジェクトが変わります(RSS1.0の場合はRSS::RDF, Atomの場合はRSS::Atom::Feedのように).
Atomの場合はタイトルとURLを取得する場合，item.title.content, item.link.hrefといったふうにメソッドを呼ばないといけないのでエラーが発生していました．

最初はfeed-normalizer gemを使おうと思ったのですが，依存gemがないことがfragileの良い点だと思うので，モジュールをつくってextendすることで問題を解決しました．
